### PR TITLE
option to use Mimic as the mocking library instead of Meck

### DIFF
--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -111,7 +111,6 @@ defmodule ExVCR.Adapter.Hackney do
   end
 
   defp handle_body_request(nil, args) do
-    #:meck.passthrough(args)
     passthrough(:mimic, args)
   end
 
@@ -126,7 +125,6 @@ defmodule ExVCR.Adapter.Hackney do
       {:ok, body}
     else
       case passthrough(:mimic, [client, max_length]) do
-      #case :meck.passthrough([client, max_length]) do
         {:ok, body} ->
           body = ExVCR.Filter.filter_sensitive_data(body)
 

--- a/lib/exvcr/adapter/hackney.ex
+++ b/lib/exvcr/adapter/hackney.ex
@@ -111,7 +111,8 @@ defmodule ExVCR.Adapter.Hackney do
   end
 
   defp handle_body_request(nil, args) do
-    :meck.passthrough(args)
+    #:meck.passthrough(args)
+    passthrough(:mimic, args)
   end
 
   defp handle_body_request(recorder, [client]) do
@@ -124,7 +125,8 @@ defmodule ExVCR.Adapter.Hackney do
       Store.delete(client_key_atom)
       {:ok, body}
     else
-      case :meck.passthrough([client, max_length]) do
+      case passthrough(:mimic, [client, max_length]) do
+      #case :meck.passthrough([client, max_length]) do
         {:ok, body} ->
           body = ExVCR.Filter.filter_sensitive_data(body)
 
@@ -142,6 +144,14 @@ defmodule ExVCR.Adapter.Hackney do
           {ret, body}
       end
     end
+  end
+
+  defp passthrough(:meck, args) when is_list(args) do
+    :meck.passthrough(args)
+  end
+
+  defp passthrough(:mimic, args) when is_list(args) do
+    Kernel.apply(Mimic.Module.original(module_name()), :body, args)
   end
 
   @doc """

--- a/lib/exvcr/mock.ex
+++ b/lib/exvcr/mock.ex
@@ -110,13 +110,13 @@ defmodule ExVCR.Mock do
   end
 
   defp initialize_mock(:meck, module_name), do: :ok
-  defp initialize_mock(:mimic, module_name), do: :ok #Mimic.copy(module_name)
+  defp initialize_mock(:mimic, module_name), do: :ok
 
   defp mock_method(:meck, module_name, function, callback), do: :meck.expect(module_name, function, callback)
   defp mock_method(:mimic, module_name, function, callback), do: Mimic.stub(module_name, function, callback)
 
   defp unload_mock(:meck, module_name), do: :meck.unload(module_name)
-  defp unload_mock(:mimic, module_name), do: :ok # Mimic.Server.reset(module_name)
+  defp unload_mock(:mimic, module_name), do: :ok
 
   @doc false
   def unload(module_name, mock_lib \\ :meck) do

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule ExVCR.Mixfile do
       {:httpoison, "~> 1.0", optional: true},
       {:excoveralls, "~> 0.13", only: :test},
       {:http_server, github: "parroty/http_server", only: [:dev, :test]},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:mimic, "~> 1.4", optional: true}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -20,6 +20,7 @@
   "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm", "5eb607516f4a644324f130d2ad8893d4097020e8d6097193d9f7be55ee8d00d6"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "mimic": {:hex, :mimic, "1.4.0", "2712fa9f26df858414cb95ba2d6f0343b0bd0f36c6a26f529e58570727d5f142", [:mix], [], "hexpm", "2c744d50bae5dac0772d624507b5a72bdd1413a73ae11291cae9264de9d0865f"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], [], "hexpm", "6e56493a862433fccc3aca3025c946d6720d8eedf6e3e6fb911952a7071c357f"},

--- a/test/adapter_hackney_mimic_test.exs
+++ b/test/adapter_hackney_mimic_test.exs
@@ -1,0 +1,236 @@
+defmodule ExVCR.Adapter.HackneyMimicTest do
+  use ExUnit.Case, async: true
+  use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney, mock_lib: :mimic
+
+  @port 34008
+
+  setup_all do
+    HttpServer.start(path: "/server", port: @port, response: "test_response")
+    {:ok, _} = HTTPoison.start
+    on_exit fn ->
+      HttpServer.stop(@port)
+    end
+    :ok
+  end
+
+  test "passthrough works when CurrentRecorder has an initial state" do
+    if ExVCR.Application.global_mock_enabled?() do
+      ExVCR.Actor.CurrentRecorder.default_state()
+      |> ExVCR.Actor.CurrentRecorder.set()
+    end
+    url = "http://localhost:#{@port}/server"
+    {:ok, status_code, _headers, _body} = :hackney.request(:get, url, [], [], [with_body: true])
+    assert status_code == 200
+  end
+
+  test "passthrough works after cassette has been used" do
+    url = "http://localhost:#{@port}/server"
+    use_cassette "hackney_get_localhost" do
+      {:ok, status_code, _headers, _body} = :hackney.request(:get, url, [], [], [with_body: true])
+      assert status_code == 200
+    end
+    {:ok, status_code, _headers, _body} = :hackney.request(:get, url, [], [], [with_body: true])
+    assert status_code == 200
+  end
+
+  test "hackney request" do
+    use_cassette "hackney_get" do
+      {:ok, status_code, headers, client} = :hackney.request(:get, "http://www.example.com", [], [], [])
+      {:ok, body} = :hackney.body(client)
+      assert body =~ ~r/Example Domain/
+      assert status_code == 200
+      assert List.keyfind(headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
+  test "hackney head request" do
+    use_cassette "hackney_head" do
+      {:ok, status_code, headers} = :hackney.request(:head, "http://www.example.com", [], [], [])
+      assert status_code == 200
+      assert List.keyfind(headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
+  test "hackney request with gzipped response" do
+    use_cassette "hackney_get_gzipped" do
+      headers = [{"Accept-Encoding", "gzip, deflate"}]
+      {:ok, status_code, headers, client} = :hackney.request(:get, "http://www.example.com", headers, [], [])
+      {:ok, body} = :hackney.body(client)
+
+      assert status_code == 200
+      assert List.keyfind(headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+
+      assert List.keyfind(headers, "Content-Encoding", 0) == {"Content-Encoding", "gzip"}
+      decoded_body = :zlib.gunzip(body)
+      assert decoded_body =~ ~r/Example Domain/
+    end
+  end
+
+  test "hackney request with path_encode_fun option" do
+    use_cassette "hackney_path_encode_fun" do
+      encode_fun = fn(x) -> :hackney_url.pathencode(x) end
+      {:ok, status_code, headers, client} =
+        :hackney.request(:get, "http://www.example.com", [], [], [path_encode_fun: encode_fun])
+      {:ok, body} = :hackney.body(client)
+      assert body =~ ~r/Example Domain/
+      assert status_code == 200
+      assert List.keyfind(headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
+  test "hackney request with error" do
+    use_cassette "error_hackney" do
+      {type, _body} = :hackney.request(:get, "http://invalid_url", [], [], [])
+      assert type == :error
+    end
+  end
+
+  test "hackney body request with invalid reference" do
+    use_cassette "hackney_invalid_client" do
+      {:ok, _status_code, _headers, client} = :hackney.request(:get, "http://www.example.com", [], [], [])
+      :hackney.body(client)
+      {ret, _body} = :hackney.body(client)
+      assert ret == :error
+    end
+  end
+
+  test "get request" do
+    use_cassette "httpoison_get" do
+      response = HTTPoison.get!("http://example.com")
+      assert response.body =~ ~r/Example Domain/
+      assert response.status_code == 200
+      assert List.keyfind(response.headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
+  test "get request with alternate" do
+    use_cassette "httpoison_get_alternate", custom: true do
+      assert %HTTPoison.Response{body: "Example Domain 1", status_code: 200} = HTTPoison.get!("http://example.com")
+      assert %HTTPoison.Response{body: "Example Domain 2", status_code: 200} = HTTPoison.get!("http://example.com")
+    end
+  end
+
+  test "get with error" do
+    use_cassette "httpoison_get_error" do
+      assert_raise HTTPoison.Error, fn ->
+        HTTPoison.get!("http://invalid_url", [])
+      end
+    end
+  end
+
+  test "get request with basic_auth" do
+    use_cassette "httpoison_get_basic_auth" do
+      response = HTTPoison.get!("http://example.com", [], [hackney: [basic_auth: {"user", "password"}]])
+      assert response.body =~ ~r/Example Domain/
+      assert response.status_code == 200
+    end
+  end
+
+  test "head request" do
+    use_cassette "httpoison_head" do
+      response = HTTPoison.head!("http://example.com")
+      assert response.body == ""
+      assert response.status_code == 200
+      assert List.keyfind(response.headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
+  test "post method" do
+    use_cassette "httpoison_post" do
+      assert_response HTTPoison.post!("http://httpbin.org/post", "test")
+    end
+  end
+
+  test "post method with ssl option" do
+    use_cassette "httpoison_post_ssl" do
+      response = HTTPoison.post!("https://example.com", {:form, []}, [], [ssl: [{:versions, [:'tlsv1.2']}]])
+      assert response.body =~ ~r/Example Domain/
+      assert response.status_code == 200
+    end
+  end
+
+  test "post with form-encoded data" do
+    use_cassette "httpoison_post_form" do
+      HTTPoison.post!("http://httpbin.org/post", {:form, [key: "value"]}, %{"Content-type" => "application/x-www-form-urlencoded"})
+    end
+  end
+
+  test "post with multipart data" do
+    File.mkdir_p("tmp/vcr_tmp")
+    File.touch!("tmp/vcr_tmp/dummy_file.txt")
+    use_cassette "httpoison_mutipart_post" do
+      HTTPoison.post!(
+        "https://httpbin.org/post",
+        {
+          :multipart,
+          [
+            {
+              :file,
+              "tmp/vcr_tmp/dummy_file.txt",
+              { ["form-data"], [name: "\"photo\"", filename: "\"dummy_file.txt\""] },
+              []
+            }
+          ]
+        },
+        [],
+        [recv_timeout: 30000]
+      )
+    end
+  end
+
+  test "put method" do
+    use_cassette "httpoison_put" do
+      assert_response HTTPoison.put!("http://httpbin.org/put", "test")
+    end
+  end
+
+  test "patch method" do
+    use_cassette "httpoison_patch" do
+      assert_response HTTPoison.patch!("http://httpbin.org/patch", "test")
+    end
+  end
+
+  test "delete method" do
+    use_cassette "httpoison_delete" do
+      assert_response HTTPoison.delete!("http://httpbin.org/delete")
+    end
+  end
+
+  test "stub request works for hackney" do
+    use_cassette :stub, [url: "http://www.example.com", body: "Stub Response"] do
+      {:ok, status_code, headers, client} = :hackney.request(:get, "http://www.example.com", [], [], [])
+      {:ok, body} = :hackney.body(client)
+      assert body =~ ~r/Stub Response/
+      assert status_code == 200
+      assert List.keyfind(headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
+  test "stub request works for HTTPoison" do
+    use_cassette :stub, [url: "http://www.example.com", body: "Stub Response"] do
+      response = HTTPoison.get!("http://www.example.com")
+      assert response.body =~ ~r/Stub Response/
+      assert response.status_code == 200
+      assert List.keyfind(response.headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+    end
+  end
+
+  for option <- [:with_body, {:with_body, true}] do
+    @option option
+
+    test "request using `#{inspect option}` option" do
+      use_cassette "hackney_with_body" do
+        {:ok, status_code, headers, body} = :hackney.request(:get, "http://www.example.com", [], [], [@option])
+        assert body =~ ~r/Example Domain/
+        assert status_code == 200
+        assert List.keyfind(headers, "Content-Type", 0) == {"Content-Type", "text/html"}
+      end
+    end
+  end
+
+  defp assert_response(response, function \\ nil) do
+    assert response.status_code == 200
+    assert is_binary(response.body)
+    unless function == nil, do: function.(response)
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,4 @@
-ExUnit.start
+Application.ensure_all_started(:mimic)
 Application.ensure_all_started(:http_server)
+Mimic.copy(:hackney)
+ExUnit.start


### PR DESCRIPTION
# Description

The ExVCR library uses mocking under the hood for intercepting the requests and provide a pre-recorded response (cassette) to a HTTP response. The mocking library used is Meck, which forbids the use of cassettes in a concurrent way.
This commit implements the option to use another mocking library, the excellent Mimic.
The implementation is not complete yet, so it is not ready to PR to the original ExVCR project. For now, it fills our requirements.

[Jira Ticket](https://coverflex.atlassian.net/browse/CX-2665)

## Type of change

Please select the options that are more relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Technical debt
- [ ] This change requires a documentation update
